### PR TITLE
Fix generation of release notes on major release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 fail_fast: true
 repos:
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:
       - id: check-json

--- a/src/scripts/create-changelog-github-releaserc.sh
+++ b/src/scripts/create-changelog-github-releaserc.sh
@@ -11,7 +11,10 @@ then
       "@semantic-release/commit-analyzer",
       { "preset": "conventionalcommits" }
     ],
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/release-notes-generator",
+      { "preset": "conventionalcommits" }
+    ],
     [
       "@semantic-release/changelog",
       { "changelogFile": "CHANGELOG.md" }

--- a/src/scripts/create-minimal-github-releaserc.sh
+++ b/src/scripts/create-minimal-github-releaserc.sh
@@ -11,7 +11,10 @@ then
       "@semantic-release/commit-analyzer",
       { "preset": "conventionalcommits" }
     ],
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/release-notes-generator",
+      { "preset": "conventionalcommits" }
+    ],
     "@semantic-release/github"
   ],
   "tagFormat": "${SEMANTIC_RELEASE_TAG_FORMAT}"


### PR DESCRIPTION
In this PR the automatic generation of _.releaserc_ file will include using the preset **conventionalcommits** for the release-notes-generator plugin. 

This fixes an issue for major releases, where the generated release notes were empty.