### PR TITLE
fix: changed node version of default executor to 19.7 to meet the 18+…

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,12 +1,12 @@
 description: >
-  Default executor using node 16.14
+  Default executor using node 19.7
 
 docker:
   - image: 'cimg/node:<<parameters.tag>>'
 
 parameters:
   tag:
-    default: "16.14"
+    default: "19.7"
     description: >
       Pick a specific circleci/node image variant:
       https://hub.docker.com/r/cimg/node/tags


### PR DESCRIPTION
… version requirement of semantic-release
